### PR TITLE
npm installに-saveオプション付けた

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation
 * Run the `npm install` command.
 
 ```
-$ npm install hubot-shubot
+$ npm install hubot-shubot -save
 ```
 
 * Add the following code in your `external-scripts.json` file.


### PR DESCRIPTION
hubot scriptの場合、-saveオプションを付けてpackage.jsonに依存関係を追加してあげた方が良いので付けました
